### PR TITLE
fix to not barf if the code changes leaving an out of date db entry

### DIFF
--- a/bin/lib/gameLonger.js
+++ b/bin/lib/gameLonger.js
@@ -97,7 +97,7 @@ class Game{
 				'variant', 'max_candidates', 'firstFewMax'
 			].forEach( field => {
 				if (!config.hasOwnProperty(field)) {
-					debug `Game.constructor: config missing field=${field}: config=${JSON.stringify(config)}`;
+					debug(`Game.constructor: config missing field=${field}: config=${JSON.stringify(config)}`);
 					missing_fields.push(field);
 				}
 				this[field] = config[field];
@@ -106,8 +106,8 @@ class Game{
 				'seedPerson', 'nextAnswer', 'answersReturned', 'linkingArticles', 'intervalDays',
 			].forEach( field => {
 				if (this.isQuestionSet && !config.hasOwnProperty(field)) {
-					debug `Game.constructor: config.isQuestionSet===true but field=${field} not defined: config=${JSON.stringify(config)}`;
-					missing_fields.psuh(field);
+					debug(`Game.constructor: config.isQuestionSet===true but field=${field} not defined: config=${JSON.stringify(config)}`);
+					missing_fields.push(field);
 				}
 				this[field] = config[field];
 			});


### PR DESCRIPTION
constructor adds an extra field, missing_fields, if it notices any missing during the copy constructor operation, leaving it to readFromDb to decide what to do about it (ie. return undefined)