### PR TITLE
Handle S3O redirects to question

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -57,7 +57,9 @@ function processResultForDisplay( result ){
 	return result;
 }
 
-router.post('^/|question', S3O);
+router.post('^(/|/question)', (req, res) => {
+	res.send(req.originalUrl);
+});
 
 router.get('/question', S3O, (req, res) => {
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -57,7 +57,7 @@ function processResultForDisplay( result ){
 	return result;
 }
 
-router.post('/|question', S3O);
+router.post('^/|question', S3O);
 
 router.get('/question', S3O, (req, res) => {
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -57,7 +57,7 @@ function processResultForDisplay( result ){
 	return result;
 }
 
-router.post('/', S3O);
+router.post('/|question', S3O);
 
 router.get('/question', S3O, (req, res) => {
 
@@ -117,7 +117,7 @@ router.get('/question', S3O, (req, res) => {
 				message : 'An error occurred as we tried to get the question.'
 			});
 		})
-
+	;
 });
 
 router.post('/answer', S3O, (req, res) => {


### PR DESCRIPTION
If the S3O token expires, and the authentication process is repeated, the `/question` endpoint will now be able to handle the `POST` request that S3O passes the token back to.